### PR TITLE
GH-939: LG leaders dashboard UI improvements

### DIFF
--- a/ui/src/components/admin/leadershipTeam/AdminLeadershipTeamContainer.js
+++ b/ui/src/components/admin/leadershipTeam/AdminLeadershipTeamContainer.js
@@ -182,7 +182,7 @@ export default function AdminLeadershipTeamContainer(props) {
     }
   };
 
-  const resetHandler = () => {
+  const unselectHandler = () => {
     setId('');
     setSeasonFrom('');
     setSeasonTo('');
@@ -229,8 +229,13 @@ export default function AdminLeadershipTeamContainer(props) {
 
         <Spacer />
 
-        <Button colorScheme="red" onClick={resetHandler} mr={2}>
-          RESET
+        <Button
+          colorScheme="blue"
+          onClick={unselectHandler}
+          mr={2}
+          isDisabled={id === ''}
+        >
+          UNSELECT
         </Button>
         <Button
           leftIcon={id !== '' ? <EditIcon /> : <AddIcon />}

--- a/ui/src/components/admin/leadershipTeam/AdminLeadershipTeamContainer.js
+++ b/ui/src/components/admin/leadershipTeam/AdminLeadershipTeamContainer.js
@@ -223,27 +223,36 @@ export default function AdminLeadershipTeamContainer(props) {
   return (
     <Container maxW="100%">
       <Flex>
-        <Heading as="h3" mb={5}>
+        <Heading as={'h3'} mb={5}>
           Leadership Team Manager
         </Heading>
 
         <Spacer />
 
-        <Button
-          colorScheme="blue"
-          onClick={unselectHandler}
-          mr={2}
-          isDisabled={id === ''}
+        <Box
+          position="absolute"
+          right={['2rem', '3rem']}
+          overflow="hidden"
+          zIndex={999}
         >
-          UNSELECT
-        </Button>
-        <Button
-          leftIcon={id !== '' ? <EditIcon /> : <AddIcon />}
-          colorScheme="teal"
-          onClick={onOpen}
-        >
-          {id !== '' ? 'EDIT' : 'ADD'}
-        </Button>
+          <Stack direction={['column', 'row']}>
+            <Button
+              colorScheme="blue"
+              onClick={unselectHandler}
+              mr={['0', '2']}
+              isDisabled={id === ''}
+            >
+              UNSELECT
+            </Button>
+            <Button
+              leftIcon={id !== '' ? <EditIcon /> : <AddIcon />}
+              colorScheme="teal"
+              onClick={onOpen}
+            >
+              {id !== '' ? 'EDIT' : 'ADD'}
+            </Button>
+          </Stack>
+        </Box>
       </Flex>
 
       <Stack direction={['column']} w="100%">


### PR DESCRIPTION
For LG leaders frontend:

- [x]  make the RESET button here more intuitive looking.
- [x]  also make these buttons to be sticky so you can see it even when you scroll to the bottom of the table