### PR TITLE
GH-1331: Add Events to Calendar Button

### DIFF
--- a/ui/src/components/easter/EasterInvitationSection.js
+++ b/ui/src/components/easter/EasterInvitationSection.js
@@ -190,11 +190,23 @@ const EasterInvitationSection = () => {
                     href={easterCalendarUrl}
                     target="_blank"
                     rel="noopener noreferrer"
+                    rightIcon={
+                      <ArrowForwardIcon
+                        display={['none', 'block']}
+                        transition="transform .18s"
+                        _groupHover={{ transform: 'translateX(6px)' }}
+                      />
+                    }
                     border="2px solid #533000"
                     bg="transparent"
                     color="#533000"
+                    transition="transform .18s ease, background-color .18s ease, box-shadow .18s ease"
+                    role="group"
                     _hover={{
+                      opacity: 0.95,
+                      transform: 'translateY(-3px)',
                       bg: 'rgba(83, 48, 0, 0.1)',
+                      boxShadow: 'lg',
                       textDecoration: 'none',
                     }}
                   >


### PR DESCRIPTION
"Add Events to Calendar" button will point to a public Google Calendar containing the Easter events 

https://calendar.google.com/calendar/u/8?cid=Y19hNzY3ODEwOGYzMjE3ZTJjNDc4MTgzMWZjZjQ0Y2IyZjg3MTk3MzhiNTY2NzliMWVlMWIzMGIwNDgxOGZkN2YyQGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20