### PR TITLE
Fix navbar button height to fixed px instead of viewport-relative vh

### DIFF
--- a/ui/src/components/NavigationBar/NavBar.js
+++ b/ui/src/components/NavigationBar/NavBar.js
@@ -221,10 +221,10 @@ const NavBar = (props) => {
                           <Button
                             textAlign="center"
                             bgColor="rgba(0, 0, 0, 0)"
-                            h="3.5vh"
+                            h="36px"
                             marginLeft="10px"
                             px={{ md: '3', lg: '5' }}
-                            py={{ md: '3', lg: '4' }}
+                            py={2}
                             _hover={{
                               backgroundColor: '#4A6EEB',
                               color: 'white',
@@ -251,10 +251,10 @@ const NavBar = (props) => {
                             color="white"
                             borderColor="#4A6EEB"
                             borderWidth="medium"
-                            h="3.5vh"
+                            h="36px"
                             marginLeft="10px"
                             px={{ md: '2', lg: '5' }}
-                            py={{ md: '3', lg: '4' }}
+                            py={2}
                             _hover={{
                               backgroundColor: '#ffffff',
                               color: 'black',
@@ -281,10 +281,10 @@ const NavBar = (props) => {
                           <Button
                             textAlign="center"
                             bgColor="rgba(0, 0, 0, 0)"
-                            h="3.5vh"
+                            h="36px"
                             marginLeft="10px"
                             px={{ md: '3', lg: '5' }}
-                            py={{ md: '3', lg: '4' }}
+                            py={2}
                             _hover={{
                               backgroundColor: '#4A6EEB',
                               color: 'white',
@@ -314,10 +314,10 @@ const NavBar = (props) => {
                             color="white"
                             borderColor="#4A6EEB"
                             borderWidth="medium"
-                            h="3.5vh"
+                            h="36px"
                             marginLeft="10px"
                             px={{ md: '2', lg: '5' }}
-                            py={{ md: '3', lg: '4' }}
+                            py={2}
                             _hover={{
                               backgroundColor: '#ffffff',
                               color: 'black',


### PR DESCRIPTION
## What

Replace viewport-relative `h="3.5vh"` with fixed `h="36px"` and replace responsive `py` values with fixed `py={2}` on all four navbar buttons (Logout, My Profile, Signup, Login).

## Why

Button height was tied to viewport height, causing buttons to appear disproportionately large or small on different screen sizes. Fixed units ensure consistent rendering across all viewports.

## Changed File

`ui/src/components/NavigationBar/NavBar.js`

Closes #1381

Requested by: Richie