### PR TITLE
GH-1416: Site Links backend — models, resolver & admin API (PR 1/3)

### DIFF
--- a/server/api/controllers/forms/get-form.js
+++ b/server/api/controllers/forms/get-form.js
@@ -1,3 +1,5 @@
+const { getFormAvailabilityCriteria } = require('../../lib/site-links');
+
 module.exports = {
   friendlyName: 'Get form route for public use',
 
@@ -20,19 +22,7 @@ module.exports = {
 
       const data = await Form.find({
         _id: id,
-        isPublished: true,
-        isDeleted: false,
-        or: [
-          {
-            formAvailableFrom: { '<=': now },
-            formAvailableUntil: { '>=': now },
-          },
-          { formAvailableFrom: { '<=': now }, formAvailableUntil: '' },
-          {
-            formAvailableFrom: '',
-            formAvailableUntil: '',
-          },
-        ],
+        ...getFormAvailabilityCriteria(now),
       });
 
       // If no form is found return error

--- a/server/api/controllers/siteLinks/admin-get-site-links.js
+++ b/server/api/controllers/siteLinks/admin-get-site-links.js
@@ -1,0 +1,42 @@
+module.exports = {
+  friendlyName: 'Admin get site links',
+
+  description:
+    'Returns every non-deleted Site Link with its non-deleted targets attached, for the admin Site Links page.',
+
+  inputs: {},
+
+  exits: {
+    success: { description: 'Site links returned successfully.' },
+    error: { description: 'Failed to fetch site links.' },
+  },
+
+  fn: async function (inputs, exits) {
+    try {
+      const siteLinks = await SiteLink.find({ isDeleted: false }).sort(
+        'label ASC'
+      );
+
+      // One query for all targets, then group in memory (avoids N+1).
+      const targets = await SiteLinkTarget.find({
+        siteLink: { in: siteLinks.map((link) => link.id) },
+        isDeleted: false,
+      }).sort('activeFrom ASC');
+
+      const targetsByLink = {};
+      targets.forEach((target) => {
+        (targetsByLink[target.siteLink] =
+          targetsByLink[target.siteLink] || []).push(target);
+      });
+
+      const withTargets = siteLinks.map((link) =>
+        Object.assign({}, link, { targets: targetsByLink[link.id] || [] })
+      );
+
+      return exits.success(withTargets);
+    } catch (err) {
+      sails.log(err);
+      return exits.error(err);
+    }
+  },
+};

--- a/server/api/controllers/siteLinks/create-site-link-target.js
+++ b/server/api/controllers/siteLinks/create-site-link-target.js
@@ -64,7 +64,7 @@ module.exports = {
       if (validationError) return exits.invalid(validationError);
 
       if (destinationType === 'form') {
-        const form = await Form.findOne({ id: formId });
+        const form = await Form.findOne({ id: formId, isDeleted: false });
         if (!form) return exits.notFound('Selected form not found.');
       }
 

--- a/server/api/controllers/siteLinks/create-site-link-target.js
+++ b/server/api/controllers/siteLinks/create-site-link-target.js
@@ -1,0 +1,87 @@
+const { validateTarget } = require('../../lib/site-links');
+
+module.exports = {
+  friendlyName: 'Create site link target',
+
+  description:
+    'Create a scheduled target for a Site Link, after validating the typed destination, safe URL/path, date range and schedule-overlap rules.',
+
+  inputs: {
+    siteLink: { type: 'string', required: true },
+    destinationType: { type: 'string', required: true },
+    formId: { type: 'string' },
+    destinationUrl: { type: 'string' },
+    activeFrom: { type: 'string' },
+    activeUntil: { type: 'string' },
+  },
+
+  exits: {
+    success: {
+      description: 'Target created.',
+    },
+    invalid: {
+      statusCode: 400,
+      description: 'The target payload failed validation.',
+    },
+    notFound: {
+      statusCode: 404,
+      description: 'Site link or referenced form not found.',
+    },
+    error: {
+      description: 'Failed to create target.',
+    },
+  },
+
+  fn: async function (inputs, exits) {
+    const user = this.req.user.fullName;
+    const {
+      siteLink,
+      destinationType,
+      formId,
+      destinationUrl,
+      activeFrom,
+      activeUntil,
+    } = inputs;
+
+    try {
+      const link = await SiteLink.findOne({ id: siteLink, isDeleted: false });
+      if (!link) return exits.notFound('Site link not found.');
+
+      const payload = {
+        destinationType,
+        formId,
+        destinationUrl,
+        activeFrom: activeFrom || '',
+        activeUntil: activeUntil || '',
+      };
+
+      const siblings = await SiteLinkTarget.find({
+        siteLink,
+        isDeleted: false,
+      });
+
+      const validationError = validateTarget(payload, siblings, null);
+      if (validationError) return exits.invalid(validationError);
+
+      if (destinationType === 'form') {
+        const form = await Form.findOne({ id: formId });
+        if (!form) return exits.notFound('Selected form not found.');
+      }
+
+      const created = await SiteLinkTarget.create({
+        siteLink,
+        destinationType,
+        formId: destinationType === 'form' ? formId : '',
+        destinationUrl: destinationType === 'url' ? destinationUrl : '',
+        activeFrom: payload.activeFrom,
+        activeUntil: payload.activeUntil,
+        updatedBy: user,
+      }).fetch();
+
+      return exits.success(created);
+    } catch (err) {
+      sails.log(err);
+      return exits.error(err);
+    }
+  },
+};

--- a/server/api/controllers/siteLinks/create-site-link-target.js
+++ b/server/api/controllers/siteLinks/create-site-link-target.js
@@ -72,7 +72,9 @@ module.exports = {
         siteLink,
         destinationType,
         formId: destinationType === 'form' ? formId : '',
-        destinationUrl: destinationType === 'url' ? destinationUrl : '',
+        // Trimmed to match what validation checked, so no stored row carries
+        // whitespace the safety check never saw.
+        destinationUrl: destinationType === 'url' ? destinationUrl.trim() : '',
         activeFrom: payload.activeFrom,
         activeUntil: payload.activeUntil,
         updatedBy: user,

--- a/server/api/controllers/siteLinks/get-redirect.js
+++ b/server/api/controllers/siteLinks/get-redirect.js
@@ -1,0 +1,69 @@
+const { findActiveTarget, resolveDestination } = require('../../lib/site-links');
+
+const UNAVAILABLE_PATH = '/link-unavailable';
+
+module.exports = {
+  friendlyName: 'Resolve site link redirect',
+
+  description:
+    'Public resolver for /go/:slug. Finds the currently active target and issues a temporary (302) redirect to its destination, or to a friendly unavailable page when nothing valid resolves.',
+
+  inputs: {
+    slug: {
+      type: 'string',
+      required: true,
+    },
+  },
+
+  exits: {
+    success: {
+      responseType: 'redirect',
+    },
+  },
+
+  fn: async function ({ slug }, exits) {
+    const res = this.res;
+    // Never cache a redirect, so a newly scheduled season is picked up at once.
+    res.set('Cache-Control', 'no-store, no-cache, must-revalidate, max-age=0');
+    res.set('Pragma', 'no-cache');
+
+    try {
+      const siteLink = await SiteLink.findOne({
+        slug,
+        isEnabled: true,
+        isDeleted: false,
+      });
+      if (!siteLink) return exits.success(UNAVAILABLE_PATH);
+
+      const targets = await SiteLinkTarget.find({
+        siteLink: siteLink.id,
+        isDeleted: false,
+      });
+
+      let now = await sails.helpers.datetime.getOffsettedTime(new Date());
+      now = now.toISOString();
+
+      const activeTarget = findActiveTarget(targets, now);
+      if (!activeTarget) return exits.success(UNAVAILABLE_PATH);
+
+      let form = null;
+      if (activeTarget.destinationType === 'form') {
+        form = await Form.findOne({ id: activeTarget.formId });
+      }
+
+      const resolved = resolveDestination(activeTarget, form, now);
+
+      if (!resolved.ok) {
+        sails.log.info(
+          `Site link /go/${slug} could not resolve: ${resolved.reason}`
+        );
+        return exits.success(UNAVAILABLE_PATH);
+      }
+
+      return exits.success(resolved.url);
+    } catch (err) {
+      sails.log(err);
+      return exits.success(UNAVAILABLE_PATH);
+    }
+  },
+};

--- a/server/api/controllers/siteLinks/get-redirect.js
+++ b/server/api/controllers/siteLinks/get-redirect.js
@@ -1,4 +1,7 @@
-const { findActiveTarget, resolveDestination } = require('../../lib/site-links');
+const {
+  findActiveTarget,
+  resolveDestination,
+} = require('../../lib/site-links');
 
 const UNAVAILABLE_PATH = '/link-unavailable';
 

--- a/server/api/controllers/siteLinks/get-redirect.js
+++ b/server/api/controllers/siteLinks/get-redirect.js
@@ -65,7 +65,10 @@ module.exports = {
 
       return exits.success(resolved.url);
     } catch (err) {
-      sails.log(err);
+      // Still send the visitor somewhere friendly, but log at error level: an
+      // infrastructure failure here is otherwise indistinguishable from a link
+      // that simply has no active target.
+      sails.log.error(`Site link /go/${slug} failed to resolve`, err);
       return exits.success(UNAVAILABLE_PATH);
     }
   },

--- a/server/api/controllers/siteLinks/get-redirect.js
+++ b/server/api/controllers/siteLinks/get-redirect.js
@@ -1,5 +1,6 @@
 const {
   findActiveTarget,
+  isValidSlug,
   resolveDestination,
 } = require('../../lib/site-links');
 
@@ -29,6 +30,10 @@ module.exports = {
     // Never cache a redirect, so a newly scheduled season is picked up at once.
     res.set('Cache-Control', 'no-store, no-cache, must-revalidate, max-age=0');
     res.set('Pragma', 'no-cache');
+
+    // Reject anything that cannot be a real slug before it reaches the database
+    // or the log lines below, so a crafted path can neither probe nor forge.
+    if (!isValidSlug(slug)) return exits.success(UNAVAILABLE_PATH);
 
     try {
       const siteLink = await SiteLink.findOne({

--- a/server/api/controllers/siteLinks/update-site-link-target.js
+++ b/server/api/controllers/siteLinks/update-site-link-target.js
@@ -74,8 +74,12 @@ module.exports = {
       const updated = await SiteLinkTarget.updateOne({ id }).set({
         destinationType: payload.destinationType,
         formId: payload.destinationType === 'form' ? payload.formId : '',
+        // Trimmed to match what validation checked, so no stored row carries
+        // whitespace the safety check never saw.
         destinationUrl:
-          payload.destinationType === 'url' ? payload.destinationUrl : '',
+          payload.destinationType === 'url'
+            ? payload.destinationUrl.trim()
+            : '',
         activeFrom: payload.activeFrom,
         activeUntil: payload.activeUntil,
         isDeleted: pick(isDeleted, existing.isDeleted),

--- a/server/api/controllers/siteLinks/update-site-link-target.js
+++ b/server/api/controllers/siteLinks/update-site-link-target.js
@@ -64,7 +64,10 @@ module.exports = {
       if (validationError) return exits.invalid(validationError);
 
       if (payload.destinationType === 'form') {
-        const form = await Form.findOne({ id: payload.formId });
+        const form = await Form.findOne({
+          id: payload.formId,
+          isDeleted: false,
+        });
         if (!form) return exits.notFound('Selected form not found.');
       }
 

--- a/server/api/controllers/siteLinks/update-site-link-target.js
+++ b/server/api/controllers/siteLinks/update-site-link-target.js
@@ -1,0 +1,88 @@
+const { validateTarget } = require('../../lib/site-links');
+
+module.exports = {
+  friendlyName: 'Update site link target',
+
+  description:
+    'Update or disable a Site Link target. A disable request (isDeleted=true) is applied directly; any destination/schedule change is re-validated.',
+
+  inputs: {
+    id: { type: 'string', required: true },
+    destinationType: { type: 'string' },
+    formId: { type: 'string' },
+    destinationUrl: { type: 'string' },
+    activeFrom: { type: 'string' },
+    activeUntil: { type: 'string' },
+    isDeleted: { type: 'boolean' },
+  },
+
+  exits: {
+    success: { description: 'Target updated.' },
+    invalid: {
+      statusCode: 400,
+      description: 'The target payload failed validation.',
+    },
+    notFound: {
+      statusCode: 404,
+      description: 'Target or referenced form not found.',
+    },
+    error: { description: 'Failed to update target.' },
+  },
+
+  fn: async function (inputs, exits) {
+    const user = this.req.user.fullName;
+    const { id, isDeleted } = inputs;
+
+    try {
+      const existing = await SiteLinkTarget.findOne({ id });
+      if (!existing) return exits.notFound('Target not found.');
+
+      // Disabling never requires a valid destination, so apply it directly.
+      if (isDeleted === true) {
+        const disabled = await SiteLinkTarget.updateOne({ id }).set({
+          isDeleted: true,
+          updatedBy: user,
+        });
+        return exits.success(disabled);
+      }
+
+      const pick = (next, prev) => (next !== undefined ? next : prev);
+      const payload = {
+        destinationType: pick(inputs.destinationType, existing.destinationType),
+        formId: pick(inputs.formId, existing.formId),
+        destinationUrl: pick(inputs.destinationUrl, existing.destinationUrl),
+        activeFrom: pick(inputs.activeFrom, existing.activeFrom) || '',
+        activeUntil: pick(inputs.activeUntil, existing.activeUntil) || '',
+      };
+
+      const siblings = await SiteLinkTarget.find({
+        siteLink: existing.siteLink,
+        isDeleted: false,
+      });
+
+      const validationError = validateTarget(payload, siblings, id);
+      if (validationError) return exits.invalid(validationError);
+
+      if (payload.destinationType === 'form') {
+        const form = await Form.findOne({ id: payload.formId });
+        if (!form) return exits.notFound('Selected form not found.');
+      }
+
+      const updated = await SiteLinkTarget.updateOne({ id }).set({
+        destinationType: payload.destinationType,
+        formId: payload.destinationType === 'form' ? payload.formId : '',
+        destinationUrl:
+          payload.destinationType === 'url' ? payload.destinationUrl : '',
+        activeFrom: payload.activeFrom,
+        activeUntil: payload.activeUntil,
+        isDeleted: pick(isDeleted, existing.isDeleted),
+        updatedBy: user,
+      });
+
+      return exits.success(updated);
+    } catch (err) {
+      sails.log(err);
+      return exits.error(err);
+    }
+  },
+};

--- a/server/api/controllers/siteLinks/update-site-link.js
+++ b/server/api/controllers/siteLinks/update-site-link.js
@@ -15,6 +15,10 @@ module.exports = {
     success: {
       description: 'Site link updated.',
     },
+    invalid: {
+      statusCode: 400,
+      description: 'No fields were supplied to update.',
+    },
     notFound: {
       statusCode: 404,
       description: 'Site link not found.',
@@ -33,6 +37,12 @@ module.exports = {
       if (label !== undefined) changes.label = label;
       if (isEnabled !== undefined) changes.isEnabled = isEnabled;
       if (isDeleted !== undefined) changes.isDeleted = isDeleted;
+
+      // Fail fast rather than reporting success for a request that changes
+      // nothing, which otherwise reads as a saved edit to the caller.
+      if (Object.keys(changes).length === 0) {
+        return exits.invalid('No fields were supplied to update.');
+      }
 
       const updated = await SiteLink.updateOne({ id }).set(changes);
       if (!updated) return exits.notFound('Site link not found.');

--- a/server/api/controllers/siteLinks/update-site-link.js
+++ b/server/api/controllers/siteLinks/update-site-link.js
@@ -1,7 +1,8 @@
 module.exports = {
   friendlyName: 'Update site link',
 
-  description: 'Update a Site Link label, enable/disable it, or soft-delete it.',
+  description:
+    'Update a Site Link label, enable/disable it, or soft-delete it.',
 
   inputs: {
     id: { type: 'string', required: true },

--- a/server/api/controllers/siteLinks/update-site-link.js
+++ b/server/api/controllers/siteLinks/update-site-link.js
@@ -1,0 +1,45 @@
+module.exports = {
+  friendlyName: 'Update site link',
+
+  description: 'Update a Site Link label, enable/disable it, or soft-delete it.',
+
+  inputs: {
+    id: { type: 'string', required: true },
+    label: { type: 'string' },
+    isEnabled: { type: 'boolean' },
+    isDeleted: { type: 'boolean' },
+  },
+
+  exits: {
+    success: {
+      description: 'Site link updated.',
+    },
+    notFound: {
+      statusCode: 404,
+      description: 'Site link not found.',
+    },
+    error: {
+      description: 'Failed to update site link.',
+    },
+  },
+
+  fn: async function ({ id, label, isEnabled, isDeleted }, exits) {
+    const user = this.req.user.fullName;
+    sails.log.info(`${user}: Updating site link: ${id}`);
+
+    try {
+      const changes = {};
+      if (label !== undefined) changes.label = label;
+      if (isEnabled !== undefined) changes.isEnabled = isEnabled;
+      if (isDeleted !== undefined) changes.isDeleted = isDeleted;
+
+      const updated = await SiteLink.updateOne({ id }).set(changes);
+      if (!updated) return exits.notFound('Site link not found.');
+
+      return exits.success(updated);
+    } catch (err) {
+      sails.log(err);
+      return exits.error(err);
+    }
+  },
+};

--- a/server/api/lib/site-links.js
+++ b/server/api/lib/site-links.js
@@ -21,7 +21,8 @@ const isSafeUrl = (value) => {
   if (!url || CONTROL_CHARS.test(url)) return false;
   const lower = url.toLowerCase();
   if (UNSAFE_PROTOCOLS.some((proto) => lower.startsWith(proto))) return false;
-  if (url.charAt(0) === '/') return url.charAt(1) !== '/' && !url.includes('\\');
+  if (url.charAt(0) === '/')
+    return url.charAt(1) !== '/' && !url.includes('\\');
   try {
     return new URL(url).protocol === 'https:';
   } catch (unusedErr) {
@@ -33,6 +34,20 @@ const isValidSlug = (slug) =>
   typeof slug === 'string' && SLUG_PATTERN.test(slug);
 
 // A form is available when published, not deleted, and now is within its window.
+// Waterline criteria equivalent to isFormAvailable, shared with /forms/:id.
+const getFormAvailabilityCriteria = (now) => ({
+  isPublished: true,
+  isDeleted: false,
+  or: [
+    {
+      formAvailableFrom: { '<=': now },
+      formAvailableUntil: { '>=': now },
+    },
+    { formAvailableFrom: { '<=': now }, formAvailableUntil: '' },
+    { formAvailableFrom: '', formAvailableUntil: { '>=': now } },
+    { formAvailableFrom: '', formAvailableUntil: '' },
+  ],
+});
 const isFormAvailable = (form, now) => {
   if (!form || form.isPublished !== true || form.isDeleted === true) {
     return false;
@@ -140,6 +155,7 @@ const validateTarget = (payload, siblings, excludeId) => {
 module.exports = {
   isSafeUrl,
   isValidSlug,
+  getFormAvailabilityCriteria,
   isFormAvailable,
   findActiveTarget,
   resolveDestination,

--- a/server/api/lib/site-links.js
+++ b/server/api/lib/site-links.js
@@ -64,20 +64,25 @@ const isFormAvailable = (form, now) => {
   return true;
 };
 
-// The active target's [activeFrom, activeUntil] window contains now (empty bound
-// = open); the latest-starting wins if several overlap.
+// The active window is half-open — activeFrom <= now < activeUntil — matching
+// rangesOverlap, so back-to-back schedules hand over cleanly instead of both
+// being active at the shared instant. An empty bound is open. Latest start wins.
 const findActiveTarget = (targets, now) => {
   const nowT = toTime(now);
   const active = (targets || []).filter((target) => {
     const from = toTime(target.activeFrom);
     const until = toTime(target.activeUntil);
-    return (from === null || nowT >= from) && (until === null || nowT <= until);
+    return (from === null || nowT >= from) && (until === null || nowT < until);
   });
-  active.sort(
-    (a, b) =>
-      (toTime(a.activeFrom) === null ? -Infinity : toTime(a.activeFrom)) -
-      (toTime(b.activeFrom) === null ? -Infinity : toTime(b.activeFrom))
-  );
+  // Open starts sort first; equal starts keep their relative order.
+  active.sort((a, b) => {
+    const aFrom = toTime(a.activeFrom);
+    const bFrom = toTime(b.activeFrom);
+    if (aFrom === bFrom) return 0;
+    if (aFrom === null) return -1;
+    if (bFrom === null) return 1;
+    return aFrom - bFrom;
+  });
   return active.length ? active[active.length - 1] : null;
 };
 

--- a/server/api/lib/site-links.js
+++ b/server/api/lib/site-links.js
@@ -14,7 +14,8 @@ const toTime = (value) => {
 };
 
 // A safe redirect destination is an absolute https URL or an internal path with
-// a single leading slash. Rejects javascript:/data:/protocol-relative/etc.
+// a single leading slash. Rejects javascript:/data:/protocol-relative/etc, and
+// /go/ paths, which would make one managed link redirect to another forever.
 const isSafeUrl = (value) => {
   if (typeof value !== 'string') return false;
   const url = value.trim();
@@ -22,7 +23,9 @@ const isSafeUrl = (value) => {
   const lower = url.toLowerCase();
   if (UNSAFE_PROTOCOLS.some((proto) => lower.startsWith(proto))) return false;
   if (url.charAt(0) === '/')
-    return url.charAt(1) !== '/' && !url.includes('\\');
+    return (
+      url.charAt(1) !== '/' && !url.includes('\\') && !lower.startsWith('/go/')
+    );
   try {
     return new URL(url).protocol === 'https:';
   } catch (unusedErr) {

--- a/server/api/lib/site-links.js
+++ b/server/api/lib/site-links.js
@@ -1,0 +1,147 @@
+/**
+ * Shared logic for Site Link redirect resolution and admin validation, kept in
+ * one place so the resolver and the admin actions apply identical rules.
+ */
+
+const UNSAFE_PROTOCOLS = ['javascript:', 'data:', 'vbscript:', 'file:'];
+const CONTROL_CHARS = /[\x00-\x1f\x7f]/;
+const SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+const toTime = (value) => {
+  if (value === undefined || value === null || value === '') return null;
+  const t = new Date(value).getTime();
+  return Number.isNaN(t) ? null : t;
+};
+
+// A safe redirect destination is an absolute https URL or an internal path with
+// a single leading slash. Rejects javascript:/data:/protocol-relative/etc.
+const isSafeUrl = (value) => {
+  if (typeof value !== 'string') return false;
+  const url = value.trim();
+  if (!url || CONTROL_CHARS.test(url)) return false;
+  const lower = url.toLowerCase();
+  if (UNSAFE_PROTOCOLS.some((proto) => lower.startsWith(proto))) return false;
+  if (url.charAt(0) === '/') return url.charAt(1) !== '/' && !url.includes('\\');
+  try {
+    return new URL(url).protocol === 'https:';
+  } catch (unusedErr) {
+    return false;
+  }
+};
+
+const isValidSlug = (slug) =>
+  typeof slug === 'string' && SLUG_PATTERN.test(slug);
+
+// A form is available when published, not deleted, and now is within its window.
+const isFormAvailable = (form, now) => {
+  if (!form || form.isPublished !== true || form.isDeleted === true) {
+    return false;
+  }
+  const nowT = toTime(now);
+  if (nowT === null) return false;
+  const from = toTime(form.formAvailableFrom);
+  const until = toTime(form.formAvailableUntil);
+  if (from !== null && nowT < from) return false;
+  if (until !== null && nowT > until) return false;
+  return true;
+};
+
+// The active target's [activeFrom, activeUntil] window contains now (empty bound
+// = open); the latest-starting wins if several overlap.
+const findActiveTarget = (targets, now) => {
+  const nowT = toTime(now);
+  const active = (targets || []).filter((target) => {
+    const from = toTime(target.activeFrom);
+    const until = toTime(target.activeUntil);
+    return (from === null || nowT >= from) && (until === null || nowT <= until);
+  });
+  active.sort(
+    (a, b) =>
+      (toTime(a.activeFrom) === null ? -Infinity : toTime(a.activeFrom)) -
+      (toTime(b.activeFrom) === null ? -Infinity : toTime(b.activeFrom))
+  );
+  return active.length ? active[active.length - 1] : null;
+};
+
+// Two schedules overlap unless one ends at/before the other starts.
+const rangesOverlap = (a, b) => {
+  const aFrom = toTime(a.activeFrom);
+  const aUntil = toTime(a.activeUntil);
+  const bFrom = toTime(b.activeFrom);
+  const bUntil = toTime(b.activeUntil);
+  if (aUntil !== null && bFrom !== null && aUntil <= bFrom) return false;
+  if (bUntil !== null && aFrom !== null && bUntil <= aFrom) return false;
+  return true;
+};
+
+// Resolve an active target to a redirect URL.
+// Returns { ok: true, url } or { ok: false, reason }.
+const resolveDestination = (target, form, now) => {
+  if (!target) return { ok: false, reason: 'no-active-target' };
+
+  if (target.destinationType === 'url') {
+    return isSafeUrl(target.destinationUrl)
+      ? { ok: true, url: target.destinationUrl.trim() }
+      : { ok: false, reason: 'unsafe-url' };
+  }
+
+  if (target.destinationType === 'form') {
+    if (!isFormAvailable(form, now)) {
+      return { ok: false, reason: 'form-unavailable' };
+    }
+    if (form.formType === 'external') {
+      return isSafeUrl(form.externalFormLink)
+        ? { ok: true, url: form.externalFormLink.trim() }
+        : { ok: false, reason: 'unsafe-external-link' };
+    }
+    return { ok: true, url: '/forms/' + (form.id || form._id) };
+  }
+
+  return { ok: false, reason: 'unknown-destination-type' };
+};
+
+// Validate an admin target payload against the typed-destination and schedule
+// rules. Returns an error message string, or null when valid. `siblings` are the
+// link's other non-deleted targets; `excludeId` is the target being updated.
+const validateTarget = (payload, siblings, excludeId) => {
+  const { destinationType, formId, destinationUrl } = payload;
+
+  if (destinationType !== 'form' && destinationType !== 'url') {
+    return 'destinationType must be "form" or "url".';
+  }
+  if (destinationType === 'form' && !formId) {
+    return 'A form must be selected for a form destination.';
+  }
+  if (destinationType === 'url') {
+    if (!destinationUrl) return 'A destination URL is required.';
+    if (!isSafeUrl(destinationUrl)) {
+      return 'The destination must be an https:// URL or a safe internal path.';
+    }
+  }
+
+  const from = toTime(payload.activeFrom);
+  const until = toTime(payload.activeUntil);
+  if (payload.activeFrom && from === null) return 'Invalid "active from" date.';
+  if (payload.activeUntil && until === null) {
+    return 'Invalid "active until" date.';
+  }
+  if (from !== null && until !== null && from >= until) {
+    return '"Active from" must be before "active until".';
+  }
+
+  const hasConflict = (siblings || []).some(
+    (t) => !t.isDeleted && t.id !== excludeId && rangesOverlap(t, payload)
+  );
+  if (hasConflict) return 'This schedule overlaps an existing target.';
+
+  return null;
+};
+
+module.exports = {
+  isSafeUrl,
+  isValidSlug,
+  isFormAvailable,
+  findActiveTarget,
+  resolveDestination,
+  validateTarget,
+};

--- a/server/api/models/SiteLink.js
+++ b/server/api/models/SiteLink.js
@@ -1,0 +1,36 @@
+/**
+ * SiteLink.js
+ *
+ * The permanent public identity for a managed redirect, e.g. `/go/life-group`.
+ * Its scheduled destinations live in the SiteLinkTarget model.
+ */
+
+module.exports = {
+  attributes: {
+    key: {
+      type: 'string',
+      required: true,
+      unique: true,
+      description: 'Stable identifier, e.g. life-group.',
+    },
+    label: {
+      type: 'string',
+      required: true,
+      description: 'Admin-facing label, e.g. LIFE Group Signup.',
+    },
+    slug: {
+      type: 'string',
+      required: true,
+      unique: true,
+      description: 'Public slug used in /go/:slug.',
+    },
+    isEnabled: {
+      type: 'boolean',
+      defaultsTo: true,
+    },
+    isDeleted: {
+      type: 'boolean',
+      defaultsTo: false,
+    },
+  },
+};

--- a/server/api/models/SiteLinkTarget.js
+++ b/server/api/models/SiteLinkTarget.js
@@ -1,0 +1,48 @@
+/**
+ * SiteLinkTarget.js
+ *
+ * One scheduled destination for a SiteLink. Exactly one of `formId` (when
+ * destinationType is `form`) or `destinationUrl` (when `url`) is populated.
+ * Timestamps are stored in UTC and displayed in the admin UI in HK time.
+ */
+
+module.exports = {
+  attributes: {
+    siteLink: {
+      type: 'string',
+      required: true,
+      description: 'Id of the SiteLink this target belongs to.',
+    },
+    destinationType: {
+      type: 'string',
+      isIn: ['form', 'url'],
+      required: true,
+    },
+    formId: {
+      type: 'string',
+      description: 'Referenced Form id; required when destinationType=form.',
+    },
+    destinationUrl: {
+      type: 'string',
+      description: 'Direct https URL or safe internal path; required when destinationType=url.',
+    },
+    activeFrom: {
+      type: 'ref',
+      columnType: 'datetime',
+      description: 'UTC start; empty = immediately active.',
+    },
+    activeUntil: {
+      type: 'ref',
+      columnType: 'datetime',
+      description: 'UTC end; empty = open-ended.',
+    },
+    updatedBy: {
+      type: 'string',
+      description: 'Full name of the authenticated user who last saved this target.',
+    },
+    isDeleted: {
+      type: 'boolean',
+      defaultsTo: false,
+    },
+  },
+};

--- a/server/api/models/SiteLinkTarget.js
+++ b/server/api/models/SiteLinkTarget.js
@@ -3,7 +3,13 @@
  *
  * One scheduled destination for a SiteLink. Exactly one of `formId` (when
  * destinationType is `form`) or `destinationUrl` (when `url`) is populated.
- * Timestamps are stored in UTC and displayed in the admin UI in HK time.
+ *
+ * Schedule bounds are Hong Kong wall-clock time carrying a literal `Z` suffix —
+ * they are NOT real UTC instants. The resolver compares them against
+ * sails.helpers.datetime.getOffsettedTime(), which is also HK wall clock, so the
+ * two sides agree. This is a convention, not a constraint: a value written with a
+ * real timezone offset would be read eight hours out, so writers must send the
+ * same shape the admin UI does.
  */
 
 module.exports = {
@@ -28,14 +34,15 @@ module.exports = {
         'Direct https URL or safe internal path; required when destinationType=url.',
     },
     activeFrom: {
-      type: 'ref',
-      columnType: 'datetime',
-      description: 'UTC start; empty = immediately active.',
+      type: 'string',
+      columnType: 'date',
+      description:
+        'HK wall-clock start labelled Z; empty = immediately active.',
     },
     activeUntil: {
-      type: 'ref',
-      columnType: 'datetime',
-      description: 'UTC end; empty = open-ended.',
+      type: 'string',
+      columnType: 'date',
+      description: 'HK wall-clock end labelled Z; empty = open-ended.',
     },
     updatedBy: {
       type: 'string',

--- a/server/api/models/SiteLinkTarget.js
+++ b/server/api/models/SiteLinkTarget.js
@@ -24,7 +24,8 @@ module.exports = {
     },
     destinationUrl: {
       type: 'string',
-      description: 'Direct https URL or safe internal path; required when destinationType=url.',
+      description:
+        'Direct https URL or safe internal path; required when destinationType=url.',
     },
     activeFrom: {
       type: 'ref',
@@ -38,7 +39,8 @@ module.exports = {
     },
     updatedBy: {
       type: 'string',
-      description: 'Full name of the authenticated user who last saved this target.',
+      description:
+        'Full name of the authenticated user who last saved this target.',
     },
     isDeleted: {
       type: 'boolean',

--- a/server/config/bootstrap.js
+++ b/server/config/bootstrap.js
@@ -38,4 +38,45 @@ module.exports.bootstrap = async function () {
     '0 0 21 * * *',
     async () => sails.helpers.parseuserquery.parseUserQuery()
   );
+
+  // Seed the permanent life-group Site Link, preserving the currently deployed
+  // destination so /go/life-group works the moment this deploys. Look up by slug
+  // regardless of isDeleted so an accidental soft-delete is repaired, not blocked
+  // by the unique slug/key constraint.
+  try {
+    let lifeGroupLink = await SiteLink.findOne({ slug: 'life-group' });
+    if (!lifeGroupLink) {
+      lifeGroupLink = await SiteLink.create({
+        key: 'life-group',
+        label: 'LIFE Group Signup',
+        slug: 'life-group',
+        isEnabled: true,
+      }).fetch();
+      sails.log.info('Seeded life-group site link');
+    } else if (lifeGroupLink.isDeleted || !lifeGroupLink.isEnabled) {
+      lifeGroupLink = await SiteLink.updateOne({ id: lifeGroupLink.id }).set({
+        isDeleted: false,
+        isEnabled: true,
+      });
+      sails.log.info('Re-enabled life-group site link');
+    }
+
+    const targetCount = await SiteLinkTarget.count({
+      siteLink: lifeGroupLink.id,
+      isDeleted: false,
+    });
+    if (targetCount === 0) {
+      await SiteLinkTarget.create({
+        siteLink: lifeGroupLink.id,
+        destinationType: 'url',
+        destinationUrl: 'https://bit.ly/summerLG26',
+        activeFrom: '',
+        activeUntil: '',
+        updatedBy: 'system-seed',
+      });
+      sails.log.info('Seeded life-group default target');
+    }
+  } catch (err) {
+    sails.log.error('Failed to seed life-group site link', err);
+  }
 };

--- a/server/config/bootstrap.js
+++ b/server/config/bootstrap.js
@@ -34,47 +34,33 @@ module.exports.bootstrap = async function () {
 
   sails.log('Initialising Parse User Query Emails Cron');
   // every EOD at 9PM
-  schedule.scheduleJob(
-    '0 0 21 * * *',
-    async () => sails.helpers.parseuserquery.parseUserQuery()
+  schedule.scheduleJob('0 0 21 * * *', async () =>
+    sails.helpers.parseuserquery.parseUserQuery()
   );
 
-  // Seed the permanent life-group Site Link, preserving the currently deployed
-  // destination so /go/life-group works the moment this deploys. Look up by slug
-  // regardless of isDeleted so an accidental soft-delete is repaired, not blocked
-  // by the unique slug/key constraint.
+  // Seed the permanent LIFE Group Site Link only when it does not exist. Once
+  // created, admin changes are authoritative and must survive deploys/restarts.
   try {
-    let lifeGroupLink = await SiteLink.findOne({ slug: 'life-group' });
-    if (!lifeGroupLink) {
-      lifeGroupLink = await SiteLink.create({
+    const existingLifeGroupLink = await SiteLink.findOne({
+      slug: 'life-group',
+    });
+    if (!existingLifeGroupLink) {
+      const lifeGroupLink = await SiteLink.create({
         key: 'life-group',
         label: 'LIFE Group Signup',
         slug: 'life-group',
         isEnabled: true,
       }).fetch();
-      sails.log.info('Seeded life-group site link');
-    } else if (lifeGroupLink.isDeleted || !lifeGroupLink.isEnabled) {
-      lifeGroupLink = await SiteLink.updateOne({ id: lifeGroupLink.id }).set({
-        isDeleted: false,
-        isEnabled: true,
-      });
-      sails.log.info('Re-enabled life-group site link');
-    }
 
-    const targetCount = await SiteLinkTarget.count({
-      siteLink: lifeGroupLink.id,
-      isDeleted: false,
-    });
-    if (targetCount === 0) {
       await SiteLinkTarget.create({
         siteLink: lifeGroupLink.id,
         destinationType: 'url',
-        destinationUrl: 'https://bit.ly/summerLG26',
+        destinationUrl: 'https://bit.ly/lifegroup2627',
         activeFrom: '',
         activeUntil: '',
         updatedBy: 'system-seed',
       });
-      sails.log.info('Seeded life-group default target');
+      sails.log.info('Seeded life-group site link and default target');
     }
   } catch (err) {
     sails.log.error('Failed to seed life-group site link', err);

--- a/server/config/bootstrap.js
+++ b/server/config/bootstrap.js
@@ -41,26 +41,35 @@ module.exports.bootstrap = async function () {
   // Seed the permanent LIFE Group Site Link only when it does not exist. Once
   // created, admin changes are authoritative and must survive deploys/restarts.
   try {
-    const existingLifeGroupLink = await SiteLink.findOne({
-      slug: 'life-group',
-    });
-    if (!existingLifeGroupLink) {
-      const lifeGroupLink = await SiteLink.create({
+    let lifeGroupLink = await SiteLink.findOne({ slug: 'life-group' });
+    if (!lifeGroupLink) {
+      lifeGroupLink = await SiteLink.create({
         key: 'life-group',
         label: 'LIFE Group Signup',
         slug: 'life-group',
         isEnabled: true,
       }).fetch();
+      sails.log.info('Seeded life-group site link');
+    }
 
-      await SiteLinkTarget.create({
+    // Checked separately from the link so a failure between the two is repaired
+    // on the next lift. Targets are soft-deleted, so a schedule the admin has
+    // emptied still counts as seeded and is never refilled.
+    if (!lifeGroupLink.isDeleted) {
+      const targetCount = await SiteLinkTarget.count({
         siteLink: lifeGroupLink.id,
-        destinationType: 'url',
-        destinationUrl: 'https://bit.ly/lifegroup2627',
-        activeFrom: '',
-        activeUntil: '',
-        updatedBy: 'system-seed',
       });
-      sails.log.info('Seeded life-group site link and default target');
+      if (targetCount === 0) {
+        await SiteLinkTarget.create({
+          siteLink: lifeGroupLink.id,
+          destinationType: 'url',
+          destinationUrl: 'https://bit.ly/lifegroup2627',
+          activeFrom: '',
+          activeUntil: '',
+          updatedBy: 'system-seed',
+        });
+        sails.log.info('Seeded default life-group site link target');
+      }
     }
   } catch (err) {
     sails.log.error('Failed to seed life-group site link', err);

--- a/server/config/policies.js
+++ b/server/config/policies.js
@@ -124,6 +124,13 @@ module.exports.policies = {
   // LeadershipTeam
   'leadershipTeam/*': ['isLoggedIn', 'aboveAdmin'],
 
+  // Site Links
+  'siteLinks/get-redirect': true,
+  'siteLinks/admin-get-site-links': ['isLoggedIn', 'aboveTc'],
+  'siteLinks/update-site-link': ['isLoggedIn', 'aboveTc'],
+  'siteLinks/create-site-link-target': ['isLoggedIn', 'aboveTc'],
+  'siteLinks/update-site-link-target': ['isLoggedIn', 'aboveTc'],
+
   // Users
   'users/reset': ['isLoggedIn', 'aboveAdmin'],
   'users/parse-user-query': ['isLoggedIn', 'aboveAdmin'],

--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -164,6 +164,15 @@ module.exports.routes = {
   'get /api/admin/parseUserQuery': 'users/parse-user-query',
   'get /api/admin/sendBatchUsersQuery': 'users/send-batch-users-query',
 
+  // Site Link admin APIs
+  'get /api/site-links/admin-get': 'siteLinks/admin-get-site-links',
+  'put /api/site-links/update': 'siteLinks/update-site-link',
+  'post /api/site-links/create-target': 'siteLinks/create-site-link-target',
+  'put /api/site-links/update-target': 'siteLinks/update-site-link-target',
+
+  // Site Link public redirect (must stay before the SPA catch-all below)
+  'get /go/:slug': 'siteLinks/get-redirect',
+
   // UI
   'get /*': {
     skipAssets: true,

--- a/ui/src/pages/screens/ErrorPage.js
+++ b/ui/src/pages/screens/ErrorPage.js
@@ -108,6 +108,14 @@ const ErrorPage = (props) => {
       buttonLink: '/',
       buttonText: 'Back to Homepage',
     },
+    'link-unavailable': {
+      type: 'error',
+      primaryText: 'This registration or link is currently unavailable.',
+      boldedText:
+        'Please check back later, or contact us at hk@hmccglobal.org',
+      buttonLink: '/',
+      buttonText: 'Back to Homepage',
+    },
     'form-is-closed': {
       type: 'error',
       primaryText:
@@ -176,6 +184,8 @@ const ErrorPage = (props) => {
           return 'need-baptized-member';
         case '/form-unavailable':
           return 'form-unavailable';
+        case '/link-unavailable':
+          return 'link-unavailable';
         case '/form-is-closed':
           return 'form-is-closed';
         case '/form-will-open':

--- a/ui/src/setupProxy.js
+++ b/ui/src/setupProxy.js
@@ -8,6 +8,15 @@ module.exports = function (app) {
     })
   );
 
+  // Site Link redirects are resolved by Sails, not the SPA. Without this, /go/*
+  // falls through to the dev server's index.html and renders the error page.
+  app.use(
+    '/go',
+    createProxyMiddleware({
+      target: 'http://localhost:1337',
+    })
+  );
+
   // To connect to production backend. DON'T USE THIS IN DEV UNLESS YOU KNOW WHAT YOU'RE DOING
   // app.use(
   //   '/api',


### PR DESCRIPTION
## PR 1 of 3 — Backend foundation

Implements the data layer and permanent redirect for [#1416](https://github.com/hmcc-global/hmcchk-web/issues/1416). No public buttons change in this PR.

### What's included
- **Models:** `SiteLink` for permanent `/go/:slug` identities and `SiteLinkTarget` for scheduled typed destinations.
- **Public resolver:** `GET /go/:slug` issues an uncached 302 or falls back to `/link-unavailable`.
- **Shared form availability:** the resolver and `forms/get-form` consume availability helpers from `api/lib/site-links.js`, including open-start / end-only windows.
- **Admin API:** protected list/update Site Link actions and create/update/disable target actions, gated by `aboveTc`.
- **Validation:** safe https/internal destinations, typed form targets, valid date ranges and non-overlapping schedules.
- **Initial seed:** creates `life-group` once with `https://bit.ly/lifegroup2627`. Existing links and targets are never re-enabled or recreated during bootstrap, so admin changes survive restarts.

### Verification
- Changed server files pass `node --check` and targeted ESLint.
- Site Links helper smoke assertions pass, including end-only form availability.
- All changed files pass Prettier.

### Deployment gate
Verify `/go/life-group` resolves to the current destination before PR #1419 is merged.

Refs #1416