### PR TITLE
GH-1416: Site Links admin page (PR 2/3)

### DIFF
--- a/ui/src/pages/MainContainer.js
+++ b/ui/src/pages/MainContainer.js
@@ -44,6 +44,7 @@ import OnlineSermonNotesRedirect from './sermon-notes/OnlineSermonNotesRedirect'
 import SermonNotesContainer from './sermon-notes/SermonNotesContainer';
 import PrivacyPolicy from './screens/PrivacyPolicy';
 import AdminFundraiseContainer from './admin/fundraise/AdminFundraiseContainer';
+import AdminSiteLinksContainer from './admin/site-links/AdminSiteLinksContainer';
 import ConnectMinistry from './discover/ConnectMinistry';
 import LifeGroupPage from './discover/LifeGroupPage';
 import StructuredData from './seo/StructuredData';
@@ -358,6 +359,12 @@ const MainContainer = () => {
           path="/admin/fundraise"
           permissions={['admin', 'stewardship']}
           component={AdminFundraiseContainer}
+        />
+        <PrivateRoute
+          exact
+          path="/admin/site-links"
+          permissions={['tc', 't3ch', 'admin', 'stewardship']}
+          component={AdminSiteLinksContainer}
         />
         <PrivateRoute path="*" permissions={['public']} component={ErrorPage} />
       </Switch>

--- a/ui/src/pages/admin/navigation/Sidebar.js
+++ b/ui/src/pages/admin/navigation/Sidebar.js
@@ -24,6 +24,7 @@ import {
   FiShield,
   FiAlertCircle,
   FiDollarSign,
+  FiLink,
 } from 'react-icons/fi';
 import { CgNotes } from 'react-icons/cg';
 
@@ -43,6 +44,7 @@ const LinkItems = [
     icon: FiShield,
     path: '/admin/leadership-team',
   },
+  { name: 'Site Links', icon: FiLink, path: '/admin/site-links' },
 ];
 
 const SidebarContent = ({ onClose, ...rest }) => {

--- a/ui/src/pages/admin/site-links/AdminSiteLinksContainer.js
+++ b/ui/src/pages/admin/site-links/AdminSiteLinksContainer.js
@@ -1,0 +1,317 @@
+import { useState, useEffect, useCallback } from 'react';
+import { customAxios as axios } from 'utils/customAxios';
+import {
+  Container,
+  Heading,
+  Box,
+  Text,
+  Button,
+  Stack,
+  HStack,
+  Badge,
+  Divider,
+  List,
+  ListItem,
+  Flex,
+  Spacer,
+  Spinner,
+  useToast,
+} from 'components';
+import SiteLinkTargetEditorModal from './SiteLinkTargetEditorModal';
+import { classifyTargets, nowIsoHk } from 'utils/siteLinks';
+
+const AdminSiteLinksContainer = () => {
+  const toast = useToast();
+  const [siteLinks, setSiteLinks] = useState([]);
+  const [forms, setForms] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isEditorOpen, setIsEditorOpen] = useState(false);
+  const [activeLink, setActiveLink] = useState(null);
+  const [activeTarget, setActiveTarget] = useState(null);
+
+  const loadData = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const [linksRes, formsRes] = await Promise.all([
+        axios.get('/api/site-links/admin-get'),
+        axios.get('/api/forms/admin-get-form'),
+      ]);
+      setSiteLinks(linksRes.data || []);
+      setForms((formsRes.data || []).filter((form) => !form.isDeleted));
+    } catch (err) {
+      console.log(err);
+      toast({
+        description:
+          'There was an issue loading site links. Please contact t3ch support.',
+        status: 'error',
+        duration: 8000,
+        isClosable: true,
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  }, [toast]);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  const formName = (formId) => {
+    const form = forms.find((item) => item.id === formId);
+    return form ? form.formName : formId;
+  };
+
+  const describeDestination = (target) => {
+    if (target.destinationType === 'url') return target.destinationUrl;
+    return `Form: ${formName(target.formId)}`;
+  };
+
+  const describeSchedule = (target) => {
+    const from = target.activeFrom || 'always';
+    const until = target.activeUntil || 'open-ended';
+    return `${from} → ${until}`;
+  };
+
+  const onAddTarget = (link) => {
+    setActiveLink(link);
+    setActiveTarget(null);
+    setIsEditorOpen(true);
+  };
+
+  const onEditTarget = (link, target) => {
+    setActiveLink(link);
+    setActiveTarget(target);
+    setIsEditorOpen(true);
+  };
+
+  const onSaved = async () => {
+    setIsEditorOpen(false);
+    await loadData();
+  };
+
+  const onDisableTarget = async (target) => {
+    if (!window.confirm('Disable this target?')) return;
+    try {
+      await axios.put('/api/site-links/update-target', {
+        id: target.id,
+        isDeleted: true,
+      });
+      toast({
+        description: 'Target disabled',
+        status: 'success',
+        duration: 5000,
+        isClosable: true,
+      });
+      await loadData();
+    } catch (err) {
+      console.log(err);
+      toast({
+        description: 'Could not disable the target',
+        status: 'error',
+        duration: 8000,
+        isClosable: true,
+      });
+    }
+  };
+
+  const onToggleLink = async (link) => {
+    try {
+      await axios.put('/api/site-links/update', {
+        id: link.id,
+        isEnabled: !link.isEnabled,
+      });
+      await loadData();
+    } catch (err) {
+      console.log(err);
+      toast({
+        description: 'Could not update the site link',
+        status: 'error',
+        duration: 8000,
+        isClosable: true,
+      });
+    }
+  };
+
+  const onCopyPath = async (slug) => {
+    const url = `${window.location.origin}/go/${slug}`;
+    try {
+      await navigator.clipboard.writeText(url);
+      toast({
+        description: `Copied ${url}`,
+        status: 'success',
+        duration: 4000,
+        isClosable: true,
+      });
+    } catch (err) {
+      console.log(err);
+      toast({
+        description: `Could not copy automatically. The link is ${url}`,
+        status: 'warning',
+        duration: 6000,
+        isClosable: true,
+      });
+    }
+  };
+
+  const renderTarget = (link, target, tone) => (
+    <ListItem key={target.id}>
+      <Flex
+        direction={['column', 'row']}
+        p={3}
+        borderWidth="1px"
+        borderRadius="md"
+        align={['stretch', 'center']}
+      >
+        <Box>
+          <HStack spacing={2} mb={1}>
+            <Badge colorScheme={tone}>
+              {target.destinationType === 'url' ? 'URL' : 'Form'}
+            </Badge>
+            <Text fontWeight="700" wordBreak="break-all">
+              {describeDestination(target)}
+            </Text>
+          </HStack>
+          <Text fontSize="sm" color="gray.600">
+            Schedule: {describeSchedule(target)}
+          </Text>
+          <Text fontSize="sm" color="gray.500">
+            Last updated by {target.updatedBy || '—'}
+            {target.updatedAt
+              ? ` on ${new Date(target.updatedAt).toLocaleString()}`
+              : ''}
+          </Text>
+        </Box>
+        <Spacer />
+        <HStack pt={[2, 0]} spacing={2}>
+          <Button
+            size="sm"
+            colorScheme="blue"
+            onClick={() => onEditTarget(link, target)}
+          >
+            Edit
+          </Button>
+          <Button
+            size="sm"
+            colorScheme="red"
+            onClick={() => onDisableTarget(target)}
+          >
+            Disable
+          </Button>
+        </HStack>
+      </Flex>
+    </ListItem>
+  );
+
+  const renderLink = (link) => {
+    const { current, upcoming, past } = classifyTargets(
+      link.targets,
+      nowIsoHk()
+    );
+    return (
+      <Box key={link.id} p={4} borderWidth="1px" borderRadius="lg" mb={5}>
+        <Flex direction={['column', 'row']} align={['stretch', 'center']}>
+          <Box>
+            <HStack spacing={2}>
+              <Heading size="md">{link.label}</Heading>
+              <Badge colorScheme={link.isEnabled ? 'green' : 'gray'}>
+                {link.isEnabled ? 'Enabled' : 'Disabled'}
+              </Badge>
+            </HStack>
+            <Text fontFamily="monospace" color="gray.700">
+              /go/{link.slug}
+            </Text>
+          </Box>
+          <Spacer />
+          <HStack pt={[2, 0]} spacing={2}>
+            <Button size="sm" onClick={() => onCopyPath(link.slug)}>
+              Copy link
+            </Button>
+            <Button
+              size="sm"
+              as="a"
+              href={`/go/${link.slug}`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Test
+            </Button>
+            <Button size="sm" onClick={() => onToggleLink(link)}>
+              {link.isEnabled ? 'Disable' : 'Enable'}
+            </Button>
+            <Button
+              size="sm"
+              colorScheme="blue"
+              onClick={() => onAddTarget(link)}
+            >
+              Add target
+            </Button>
+          </HStack>
+        </Flex>
+
+        <Divider my={3} />
+
+        <Text fontWeight="700">Current</Text>
+        <List spacing={2} mt={1} mb={3}>
+          {current.length > 0 ? (
+            current.map((target) => renderTarget(link, target, 'green'))
+          ) : (
+            <Text fontSize="sm" color="gray.500">
+              No active target — /go/{link.slug} shows the unavailable page.
+            </Text>
+          )}
+        </List>
+
+        {upcoming.length > 0 && (
+          <>
+            <Text fontWeight="700">Upcoming</Text>
+            <List spacing={2} mt={1} mb={3}>
+              {upcoming.map((target) => renderTarget(link, target, 'purple'))}
+            </List>
+          </>
+        )}
+
+        {past.length > 0 && (
+          <>
+            <Text fontWeight="700">Past</Text>
+            <List spacing={2} mt={1}>
+              {past.map((target) => renderTarget(link, target, 'gray'))}
+            </List>
+          </>
+        )}
+      </Box>
+    );
+  };
+
+  return (
+    <Container maxW="container.xl">
+      <Heading as="h1" size="xl" pb={2}>
+        Site Links
+      </Heading>
+      <Text color="gray.600" mb={5}>
+        Manage permanent redirect paths (e.g. /go/life-group) and schedule which
+        destination each one points to — no code deploy needed.
+      </Text>
+
+      {isLoading ? (
+        <Stack align="center" py={10}>
+          <Spinner />
+        </Stack>
+      ) : siteLinks.length === 0 ? (
+        <Text color="gray.500">No site links yet.</Text>
+      ) : (
+        siteLinks.map((link) => renderLink(link))
+      )}
+
+      <SiteLinkTargetEditorModal
+        isOpen={isEditorOpen}
+        onClose={() => setIsEditorOpen(false)}
+        siteLink={activeLink}
+        target={activeTarget}
+        forms={forms}
+        onSaved={onSaved}
+      />
+    </Container>
+  );
+};
+
+export default AdminSiteLinksContainer;

--- a/ui/src/pages/admin/site-links/SiteLinkTargetEditorModal.js
+++ b/ui/src/pages/admin/site-links/SiteLinkTargetEditorModal.js
@@ -1,0 +1,338 @@
+import { useEffect, useMemo } from 'react';
+import { useForm, Controller } from 'react-hook-form';
+import { customAxios as axios } from 'utils/customAxios';
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalCloseButton,
+  ModalBody,
+  ModalFooter,
+  Button,
+  FormControl,
+  FormLabel,
+  FormErrorMessage,
+  FormHelperText,
+  Input,
+  Select,
+  RadioGroup,
+  Radio,
+  Stack,
+  HStack,
+  Box,
+  Text,
+  Badge,
+  Alert,
+  AlertIcon,
+  Divider,
+  Link,
+  useToast,
+} from 'components';
+import {
+  isSafeDestinationUrl,
+  toStoredIso,
+  toLocalInput,
+  resolvePreview,
+  scheduleOutsideForm,
+  nowIsoHk,
+} from 'utils/siteLinks';
+
+const EMPTY_VALUES = {
+  destinationType: 'form',
+  formId: '',
+  destinationUrl: '',
+  activeFrom: '',
+  activeUntil: '',
+};
+
+const SiteLinkTargetEditorModal = (props) => {
+  const { isOpen, onClose, siteLink, target, forms, onSaved } = props;
+  const toast = useToast();
+  const {
+    register,
+    handleSubmit,
+    control,
+    watch,
+    reset,
+    setValue,
+    getValues,
+    formState: { errors, isSubmitting },
+  } = useForm({ mode: 'onChange', defaultValues: EMPTY_VALUES });
+
+  useEffect(() => {
+    if (!isOpen) return;
+    reset(
+      target
+        ? {
+            destinationType: target.destinationType || 'form',
+            formId: target.formId || '',
+            destinationUrl: target.destinationUrl || '',
+            activeFrom: toLocalInput(target.activeFrom),
+            activeUntil: toLocalInput(target.activeUntil),
+          }
+        : EMPTY_VALUES
+    );
+  }, [isOpen, target, reset]);
+
+  const destinationType = watch('destinationType');
+  const formId = watch('formId');
+  const destinationUrl = watch('destinationUrl');
+  const activeFrom = watch('activeFrom');
+  const activeUntil = watch('activeUntil');
+
+  const selectedForm = useMemo(
+    () => (forms || []).find((form) => form.id === formId) || null,
+    [forms, formId]
+  );
+
+  const formField = register('formId', {
+    validate: (value, values) =>
+      values.destinationType !== 'form' ||
+      Boolean(value) ||
+      'Please select a form.',
+  });
+
+  // Prefill the schedule from the form's availability window when empty.
+  const onFormSelect = (e) => {
+    formField.onChange(e);
+    const form = (forms || []).find((item) => item.id === e.target.value);
+    if (form) {
+      if (!getValues('activeFrom') && form.formAvailableFrom) {
+        setValue('activeFrom', toLocalInput(form.formAvailableFrom));
+      }
+      if (!getValues('activeUntil') && form.formAvailableUntil) {
+        setValue('activeUntil', toLocalInput(form.formAvailableUntil));
+      }
+    }
+  };
+
+  const pseudoTarget = {
+    destinationType,
+    formId,
+    destinationUrl,
+    activeFrom: toStoredIso(activeFrom),
+    activeUntil: toStoredIso(activeUntil),
+  };
+  const preview = resolvePreview(pseudoTarget, selectedForm, nowIsoHk());
+  const scheduleWarning = scheduleOutsideForm(pseudoTarget, selectedForm);
+
+  const onSubmit = async (values) => {
+    const payload = {
+      destinationType: values.destinationType,
+      formId: values.destinationType === 'form' ? values.formId : '',
+      destinationUrl:
+        values.destinationType === 'url' ? values.destinationUrl : '',
+      activeFrom: toStoredIso(values.activeFrom),
+      activeUntil: toStoredIso(values.activeUntil),
+    };
+    try {
+      if (target) {
+        await axios.put('/api/site-links/update-target', {
+          id: target.id,
+          ...payload,
+        });
+      } else {
+        await axios.post('/api/site-links/create-target', {
+          siteLink: siteLink.id,
+          ...payload,
+        });
+      }
+      toast({
+        description: 'Target saved',
+        status: 'success',
+        duration: 5000,
+        isClosable: true,
+      });
+      onSaved();
+    } catch (err) {
+      console.log(err);
+      const data = err.response && err.response.data;
+      const message =
+        (typeof data === 'string' && data) ||
+        (data && data.message) ||
+        'Could not save target. Please check the fields and try again.';
+      toast({
+        description: message,
+        status: 'error',
+        duration: 8000,
+        isClosable: true,
+      });
+    }
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} size="xl" scrollBehavior="inside">
+      <ModalOverlay />
+      <ModalContent as="form" onSubmit={handleSubmit(onSubmit)}>
+        <ModalHeader>
+          {target ? 'Edit target' : 'Add target'}
+          {siteLink ? ` — /go/${siteLink.slug}` : ''}
+        </ModalHeader>
+        <ModalCloseButton />
+        <ModalBody>
+          <Stack spacing={4}>
+            <FormControl>
+              <FormLabel>Destination type</FormLabel>
+              <Controller
+                name="destinationType"
+                control={control}
+                render={({ field }) => (
+                  <RadioGroup {...field}>
+                    <Stack direction="row" spacing={6}>
+                      <Radio value="form">Existing Form</Radio>
+                      <Radio value="url">Direct URL</Radio>
+                    </Stack>
+                  </RadioGroup>
+                )}
+              />
+            </FormControl>
+
+            {destinationType === 'form' && (
+              <FormControl isRequired isInvalid={Boolean(errors.formId)}>
+                <FormLabel>Form</FormLabel>
+                <Select
+                  placeholder="Select a form"
+                  {...formField}
+                  onChange={onFormSelect}
+                >
+                  {(forms || []).map((form) => (
+                    <option key={form.id} value={form.id}>
+                      {form.formName}{' '}
+                      {form.formType === 'external'
+                        ? '(external)'
+                        : '(internal)'}
+                    </option>
+                  ))}
+                </Select>
+                <FormErrorMessage>
+                  {errors.formId && errors.formId.message}
+                </FormErrorMessage>
+                {selectedForm && (
+                  <Box mt={2} fontSize="sm">
+                    <HStack spacing={2}>
+                      <Badge
+                        colorScheme={
+                          selectedForm.formType === 'external'
+                            ? 'orange'
+                            : 'teal'
+                        }
+                      >
+                        {selectedForm.formType === 'external'
+                          ? 'External'
+                          : 'Internal'}
+                      </Badge>
+                      <Badge
+                        colorScheme={selectedForm.isPublished ? 'green' : 'red'}
+                      >
+                        {selectedForm.isPublished ? 'Published' : 'Unpublished'}
+                      </Badge>
+                    </HStack>
+                    <Text mt={1} color="gray.600">
+                      Available: {selectedForm.formAvailableFrom || '—'} to{' '}
+                      {selectedForm.formAvailableUntil || '—'}
+                    </Text>
+                  </Box>
+                )}
+              </FormControl>
+            )}
+
+            {destinationType === 'url' && (
+              <FormControl
+                isRequired
+                isInvalid={Boolean(errors.destinationUrl)}
+              >
+                <FormLabel>Destination URL or path</FormLabel>
+                <Input
+                  placeholder="https://… or /internal/path"
+                  {...register('destinationUrl', {
+                    validate: (value, values) =>
+                      values.destinationType !== 'url' ||
+                      (Boolean(value) && isSafeDestinationUrl(value)) ||
+                      'Must be an https:// URL or a safe internal path.',
+                  })}
+                />
+                <FormErrorMessage>
+                  {errors.destinationUrl && errors.destinationUrl.message}
+                </FormErrorMessage>
+                <FormHelperText>
+                  javascript:, data:, and protocol-relative (//) links are
+                  rejected.
+                </FormHelperText>
+              </FormControl>
+            )}
+
+            <Divider />
+
+            <HStack spacing={4} align="start">
+              <FormControl>
+                <FormLabel>Active from (HK time)</FormLabel>
+                <Input type="datetime-local" {...register('activeFrom')} />
+                <FormHelperText>Empty = immediately active.</FormHelperText>
+              </FormControl>
+              <FormControl isInvalid={Boolean(errors.activeUntil)}>
+                <FormLabel>Active until (HK time)</FormLabel>
+                <Input
+                  type="datetime-local"
+                  {...register('activeUntil', {
+                    validate: (value, values) =>
+                      !value ||
+                      !values.activeFrom ||
+                      new Date(toStoredIso(values.activeFrom)).getTime() <
+                        new Date(toStoredIso(value)).getTime() ||
+                      'End must be after start.',
+                  })}
+                />
+                <FormErrorMessage>
+                  {errors.activeUntil && errors.activeUntil.message}
+                </FormErrorMessage>
+                <FormHelperText>Empty = open-ended.</FormHelperText>
+              </FormControl>
+            </HStack>
+
+            {scheduleWarning && (
+              <Alert status="warning" borderRadius="md">
+                <AlertIcon />
+                This schedule falls outside the selected form&apos;s
+                availability period.
+              </Alert>
+            )}
+
+            <Box borderWidth="1px" borderRadius="md" p={3} bgColor="gray.50">
+              <Text fontWeight="700" mb={1}>
+                Preview (resolves now to):
+              </Text>
+              {preview.ok ? (
+                <Text wordBreak="break-all" color="green.700">
+                  {preview.url}
+                </Text>
+              ) : (
+                <Text color="red.600">Unavailable — {preview.reason}</Text>
+              )}
+              {siteLink && (
+                <Link
+                  href={`/go/${siteLink.slug}`}
+                  isExternal
+                  color="blue.600"
+                  fontSize="sm"
+                >
+                  Test /go/{siteLink.slug} ↗
+                </Link>
+              )}
+            </Box>
+          </Stack>
+        </ModalBody>
+        <ModalFooter>
+          <Button variant="ghost" mr={3} onClick={onClose}>
+            Cancel
+          </Button>
+          <Button colorScheme="blue" type="submit" isLoading={isSubmitting}>
+            Save target
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+};
+
+export default SiteLinkTargetEditorModal;

--- a/ui/src/utils/siteLinks.js
+++ b/ui/src/utils/siteLinks.js
@@ -1,0 +1,141 @@
+/**
+ * Client-side helpers for the admin Site Links page.
+ *
+ * `isSafeDestinationUrl` mirrors the server rule (server stays the source of
+ * truth; this is only for immediate admin feedback). The date helpers convert
+ * between the `datetime-local` input value and the stored ISO string: the
+ * server compares schedules against Hong Kong wall-clock time (via
+ * getOffsettedTime), so we persist the picked wall-clock value labelled as UTC.
+ */
+
+const UNSAFE_PROTOCOLS = ['javascript:', 'data:', 'vbscript:', 'file:'];
+// eslint-disable-next-line no-control-regex
+const CONTROL_CHARS = /[\x00-\x1f\x7f]/;
+
+export const isSafeDestinationUrl = (value) => {
+  if (typeof value !== 'string') return false;
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return false;
+  if (CONTROL_CHARS.test(trimmed)) return false;
+
+  const lower = trimmed.toLowerCase();
+  if (UNSAFE_PROTOCOLS.some((proto) => lower.startsWith(proto))) return false;
+
+  if (trimmed.charAt(0) === '/') {
+    if (trimmed.charAt(1) === '/') return false;
+    if (trimmed.indexOf('\\') !== -1) return false;
+    return true;
+  }
+
+  try {
+    return new URL(trimmed).protocol === 'https:';
+  } catch {
+    return false;
+  }
+};
+
+// 'YYYY-MM-DDTHH:mm' (datetime-local) -> 'YYYY-MM-DDTHH:mm:00.000Z' (stored).
+export const toStoredIso = (localValue) => {
+  if (!localValue) return '';
+  let value = String(localValue).trim();
+  if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/.test(value)) value += ':00';
+  if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/.test(value)) value += '.000Z';
+  return value;
+};
+
+// Stored ISO -> 'YYYY-MM-DDTHH:mm' for the datetime-local input. Components are
+// taken verbatim (they are HK wall-clock time labelled Z), with no tz math.
+export const toLocalInput = (storedIso) => {
+  if (!storedIso) return '';
+  const match = String(storedIso).match(/^(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2})/);
+  return match ? `${match[1]}T${match[2]}` : '';
+};
+
+// The server compares schedules against HK wall-clock time (getOffsettedTime);
+// mirror that here for previews and target classification.
+export const nowIsoHk = () =>
+  new Date(Date.now() + 8 * 60 * 60 * 1000).toISOString();
+
+const toTime = (value) => {
+  if (value === undefined || value === null || value === '') return null;
+  let v = String(value);
+  // Treat a timezone-less datetime as HK wall-clock (labelled Z), matching how
+  // target schedules are stored, so comparisons stay in one time base.
+  if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2})?$/.test(v)) {
+    v += v.length === 16 ? ':00.000Z' : '.000Z';
+  }
+  const t = new Date(v).getTime();
+  return Number.isNaN(t) ? null : t;
+};
+
+// Split a link's targets into current / upcoming / past relative to `nowIso`.
+export const classifyTargets = (targets, nowIso) => {
+  const now = new Date(nowIso).getTime();
+  const current = [];
+  const upcoming = [];
+  const past = [];
+  (targets || []).forEach((target) => {
+    const from = toTime(target.activeFrom);
+    const until = toTime(target.activeUntil);
+    if (from !== null && from > now) upcoming.push(target);
+    else if (until !== null && until <= now) past.push(target);
+    else current.push(target);
+  });
+  return { current, upcoming, past };
+};
+
+export const isFormAvailableAt = (form, nowIso) => {
+  if (!form) return false;
+  if (form.isPublished !== true) return false;
+  if (form.isDeleted === true) return false;
+  const now = new Date(nowIso).getTime();
+  if (Number.isNaN(now)) return false;
+  const from = toTime(form.formAvailableFrom);
+  const until = toTime(form.formAvailableUntil);
+  if (from !== null && now < from) return false;
+  if (until !== null && now > until) return false;
+  return true;
+};
+
+// Preview the destination a target would resolve to right now (mirrors the
+// server resolver, for the admin's test/preview panel).
+export const resolvePreview = (target, form, nowIso) => {
+  if (!target) return { ok: false, reason: 'No target' };
+
+  if (target.destinationType === 'url') {
+    return isSafeDestinationUrl(target.destinationUrl)
+      ? { ok: true, url: target.destinationUrl.trim() }
+      : { ok: false, reason: 'Unsafe or invalid URL' };
+  }
+
+  if (target.destinationType === 'form') {
+    if (!form) return { ok: false, reason: 'Selected form not found' };
+    if (!isFormAvailableAt(form, nowIso)) {
+      return {
+        ok: false,
+        reason: 'Form is unpublished, deleted or out of date',
+      };
+    }
+    if (form.formType === 'external') {
+      return isSafeDestinationUrl(form.externalFormLink)
+        ? { ok: true, url: form.externalFormLink.trim() }
+        : { ok: false, reason: 'Form has an unsafe external link' };
+    }
+    return { ok: true, url: `/forms/${form.id}` };
+  }
+
+  return { ok: false, reason: 'Unknown destination type' };
+};
+
+// True when the target's schedule falls outside the selected form's own
+// availability window (used to warn the admin before saving).
+export const scheduleOutsideForm = (target, form) => {
+  if (!form || target.destinationType !== 'form') return false;
+  const tFrom = toTime(target.activeFrom);
+  const tUntil = toTime(target.activeUntil);
+  const fFrom = toTime(form.formAvailableFrom);
+  const fUntil = toTime(form.formAvailableUntil);
+  if (fFrom !== null && (tFrom === null || tFrom < fFrom)) return true;
+  if (fUntil !== null && (tUntil === null || tUntil > fUntil)) return true;
+  return false;
+};


### PR DESCRIPTION
## PR 2 of 3 — Admin Site Links page

> Stacked on [#1417](https://github.com/hmcc-global/hmcchk-web/pull/1417). Review and merge PR 1 first.

Adds the admin UI for [#1416](https://github.com/hmcc-global/hmcchk-web/issues/1416), allowing authorized users to manage current and scheduled destinations without code changes.

### What's included
- `/admin/site-links` route and sidebar entry; route and backend access use the same `tc`, `t3ch`, `admin`, and `stewardship` roles as Form Manager.
- List view showing the permanent `/go/:slug` path, copy/test actions, enable/disable control, and current/upcoming/past targets.
- Target editor for Existing Form or Direct URL destinations.
- HK-time scheduling, form-availability warnings, safe destination validation and live destination preview.
- Repository formatting applied across the Site Links admin surface.

### Verification
- Targeted frontend ESLint passes with no errors; the defensive `javascript:` protocol literal produces one existing `no-script-url` warning.
- `CI=false npm run build` completes successfully on the available Node 24 runtime.
- All changed files pass Prettier.
- The repository Jest command remains blocked before executing tests by the unrelated Luxon deep import in `CurrentSermon.js`.

### Deployment gate
An authorized admin should be able to edit the LIFE Group target and verify `/go/life-group` before PR #1419 is merged.

Refs #1416