### PR TITLE
GH-1416: migrate LIFE Group links to /go/life-group (PR 3/3)

### DIFF
--- a/ui/src/pages/discover/Faq.js
+++ b/ui/src/pages/discover/Faq.js
@@ -96,11 +96,7 @@ const Faq = (props) => {
           <br />
           If you’re not sure who the leader of the LIFE Group is, please contact
           us by dropping an email{' '}
-          <Link
-            href="mailto:hk@hmccglobal.org"
-            fontStyle="italic"
-            color="blue"
-          >
+          <Link href="mailto:hk@hmccglobal.org" fontStyle="italic" color="blue">
             here
           </Link>
         </AccordionPanel>
@@ -121,11 +117,7 @@ const Faq = (props) => {
           adult (focus) ministry/ married couple (covenant) ministry. Feel free
           to send an Instagram direct message on the appropriate Instagram
           profile and/or drop an email{' '}
-          <Link
-            href="mailto:hk@hmccglobal.org"
-            fontStyle="italic"
-            color="blue"
-          >
+          <Link href="mailto:hk@hmccglobal.org" fontStyle="italic" color="blue">
             here
           </Link>{' '}
           to learn more.

--- a/ui/src/utils/constants.js
+++ b/ui/src/utils/constants.js
@@ -1,4 +1,4 @@
 // Permanent, admin-managed redirect paths. The destination each one points to
 // is configured in the admin Site Links page (/admin/site-links) and resolved
 // server-side by GET /go/:slug — change the destination there, not here.
-export const LIFE_GROUP_SIGNUP_PATH = 'https://bit.ly/lifegroup2627';
+export const LIFE_GROUP_SIGNUP_PATH = '/go/life-group';


### PR DESCRIPTION
## PR 3 of 3 — Cut over to the managed redirect

The urgent public-link migration already landed through [#1420](https://github.com/hmcc-global/hmcchk-web/pull/1420), with the shared constant temporarily pointing to `https://bit.ly/lifegroup2627`.

This PR is now restacked directly on current `main` and contains only the final cutover:
- Change `LIFE_GROUP_SIGNUP_PATH` from the urgent hardcoded Bitly destination to `/go/life-group`.
- Apply repository formatting to the touched FAQ file.

The duplicate migration changes from #1420 are no longer part of this diff, resolving the previous conflict with `main`.

### Verification
- Targeted frontend ESLint passes for the touched FAQ file.
- `CI=false npm run build` completes successfully on the available Node 24 runtime.
- Changed files pass Prettier.

### Deployment gate
Merge only after PR #1417 is deployed and `/go/life-group` is confirmed to resolve to the current production destination. PR #1418 supplies the admin management UI.

Closes #1416