### PR TITLE
GH-1: Fix google error

### DIFF
--- a/ui/src/index.js
+++ b/ui/src/index.js
@@ -7,26 +7,9 @@ import { ChakraProvider } from 'components';
 import { GoogleOAuthProvider } from '@react-oauth/google';
 import customTheme from './theme';
 
-const onScriptLoaded = () => {
-  // Remove any GSI scripts already in the DOM — both the library's bare-URL injections
-  // and our own ?hl=en copies — matched by src prefix so repeat invocations don't
-  // accumulate duplicates. .remove() is safe regardless of which parent holds them.
-  document
-    .querySelectorAll(
-      '[src^="https://accounts.google.com/gsi/client"],[src^="https://accounts.google.com/gsi/select"]'
-    )
-    .forEach((el) => el.remove());
-  const scriptTag = document.createElement('script');
-  const selectScriptTag = document.createElement('script');
-  scriptTag.src = 'https://accounts.google.com/gsi/client?hl=en';
-  selectScriptTag.src = 'https://accounts.google.com/gsi/select?hl=en';
-  document.body.appendChild(scriptTag);
-  document.body.appendChild(selectScriptTag);
-};
-
 const root = createRoot(document.getElementById('root'));
 root.render(
-  <GoogleOAuthProvider clientId={import.meta.env.REACT_APP_GOOGLE_CLIENT_ID} onScriptLoadSuccess={onScriptLoaded}>
+  <GoogleOAuthProvider clientId={import.meta.env.REACT_APP_GOOGLE_CLIENT_ID}>
     <React.StrictMode>
       <ChakraProvider theme={customTheme}>
         <App />


### PR DESCRIPTION
The PR addresses a bug that only occurs on safari when loading the login page. Login page currently showing error due to Google button loading twice via the hack injection