### PR TITLE
GH-1431: route profile tabs to /profile/<slug>

### DIFF
--- a/ui/src/pages/MainContainer.js
+++ b/ui/src/pages/MainContainer.js
@@ -246,7 +246,7 @@ const MainContainer = () => {
           />
           <PrivateRoute
             exact
-            path="/profile"
+            path="/profile/:tab?"
             permissions={[
               'unsigned',
               'signed',

--- a/ui/src/pages/PrivateRoute.js
+++ b/ui/src/pages/PrivateRoute.js
@@ -107,21 +107,22 @@ const PrivateRoute = ({ component: Component, permissions, ...rest }) => {
               return <HomeContainer {...props} user={userObj} />;
             }
           } else if (access) {
-            switch (props.location.pathname) {
-              case '/complete-profile':
-                if (userObj.hasFilledProfileForm) {
-                  props.history.push('/profile');
-                  return <UserProfileContainer {...props} user={userObj} />;
-                }
-                break;
-              case '/profile':
-                if (!userObj.hasFilledProfileForm) {
-                  props.history.push('/complete-profile');
-                  return (
-                    <CompleteUserProfileContainer {...props} user={userObj} />
-                  );
-                }
-                break;
+            const { pathname } = props.location;
+            // Matches /profile as well as the per-tab /profile/<slug> paths.
+            const isProfilePath =
+              pathname === '/profile' || pathname.startsWith('/profile/');
+
+            if (
+              pathname === '/complete-profile' &&
+              userObj.hasFilledProfileForm
+            ) {
+              props.history.push('/profile');
+              return <UserProfileContainer {...props} user={userObj} />;
+            }
+
+            if (isProfilePath && !userObj.hasFilledProfileForm) {
+              props.history.push('/complete-profile');
+              return <CompleteUserProfileContainer {...props} user={userObj} />;
             }
 
             if (props.location.pathname.includes('admin'))

--- a/ui/src/pages/userProfile/UserProfileContainer.js
+++ b/ui/src/pages/userProfile/UserProfileContainer.js
@@ -1,8 +1,29 @@
 import { Container, Box } from 'components';
+import { Redirect } from 'react-router-dom';
 import UserProfileDesktop from './UserProfileDesktop';
 import UserProfileMobile from './UserProfileMobile';
+import {
+  DEFAULT_PROFILE_TAB,
+  getProfileTabIndex,
+  getProfileTabSlug,
+} from './profileTabs';
 
 const UserProfileContainer = (props) => {
+  const { match, history } = props;
+  const activeTabIndex = getProfileTabIndex(match?.params?.tab);
+
+  // Covers a bare /profile, an unknown slug, and the branches of PrivateRoute
+  // that render this container without a :tab param.
+  if (activeTabIndex === -1) {
+    return <Redirect to={`/profile/${DEFAULT_PROFILE_TAB}`} />;
+  }
+
+  const handleTabChange = (index) => {
+    history.push(`/profile/${getProfileTabSlug(index)}`);
+  };
+
+  const tabProps = { activeTabIndex, onTabChange: handleTabChange };
+
   return (
     <Box>
       {/* Breaks footer... commenting out until fixable */}
@@ -21,7 +42,7 @@ const UserProfileContainer = (props) => {
         position="relative"
         display={{ base: 'none', md: 'block' }}
       >
-        <UserProfileDesktop {...props} />
+        <UserProfileDesktop {...props} {...tabProps} />
       </Container>
 
       <Container
@@ -30,7 +51,7 @@ const UserProfileContainer = (props) => {
         position="relative"
         display={{ base: 'block', md: 'none' }}
       >
-        <UserProfileMobile {...props} />
+        <UserProfileMobile {...props} {...tabProps} />
       </Container>
     </Box>
   );

--- a/ui/src/pages/userProfile/UserProfileDesktop.js
+++ b/ui/src/pages/userProfile/UserProfileDesktop.js
@@ -45,9 +45,10 @@ import {
   generatePublishedFormLinks,
 } from 'utils/userInformationHelpers';
 import SermonNotesPagination from './SermonNotesPagination';
+import { PROFILE_TABS } from './profileTabs';
 
 const UserProfileDesktop = (props) => {
-  const { user, staticData } = props;
+  const { user, staticData, activeTabIndex, onTabChange } = props;
   const { lifegroupList, lifestageList, campusList } = staticData;
 
   const { register, control, handleSubmit, setValue, formState } = useForm();
@@ -311,21 +312,26 @@ const UserProfileDesktop = (props) => {
         </Box>
       </Flex>
       <form onSubmit={handleSubmit(handleEditUserInformation)}>
-        <Tabs mt="5%" mb="5%" orientation="vertical" variant="unstyled">
+        <Tabs
+          mt="5%"
+          mb="5%"
+          orientation="vertical"
+          variant="unstyled"
+          index={activeTabIndex}
+          onChange={onTabChange}
+        >
           <Box flex={1}>
             <TabList border="none" alignItems="flex-end">
-              <Tab style={tabTitle} _selected={{ md: tabText }}>
-                Signup Links
-              </Tab>
-              <Tab style={tabTitle} _selected={{ md: tabText }} mt={5}>
-                Sermon Notes
-              </Tab>
-              <Tab style={tabTitle} _selected={{ md: tabText }} mt={5}>
-                Personal Profile
-              </Tab>
-              <Tab style={tabTitle} _selected={{ md: tabText }} mt={5}>
-                Church Profile
-              </Tab>
+              {PROFILE_TABS.map((tab, index) => (
+                <Tab
+                  key={tab.slug}
+                  style={tabTitle}
+                  _selected={{ md: tabText }}
+                  mt={index === 0 ? 0 : 5}
+                >
+                  {tab.label}
+                </Tab>
+              ))}
             </TabList>
           </Box>
           <TabPanels

--- a/ui/src/pages/userProfile/UserProfileMobile.js
+++ b/ui/src/pages/userProfile/UserProfileMobile.js
@@ -43,9 +43,10 @@ import {
   generatePublishedFormLinks,
 } from 'utils/userInformationHelpers';
 import SermonNotesPagination from './SermonNotesPagination';
+import { PROFILE_TABS } from './profileTabs';
 
 const UserProfileMobile = (props) => {
-  const { user, staticData } = props;
+  const { user, staticData, activeTabIndex, onTabChange } = props;
   const { lifegroupList, lifestageList, campusList } = staticData;
 
   const { register, control, handleSubmit, setValue, formState } = useForm();
@@ -55,7 +56,6 @@ const UserProfileMobile = (props) => {
   const [unsignedFormList, setUnsignedFormList] = useState([]);
   const [signedUpFormList, setSignedUpFormList] = useState([]);
   const [modalOpen, setModalOpen] = useState(false);
-  const [activeIndex, setActiveIndex] = useState(0);
   const [activeSermonNoteTab, setActiveSermonNoteTab] = useState('all');
   const [userSermonNotes, setUserSermonNotes] = useState([]);
   const [sermonSeriesList, setSermonSeriesList] = useState([]);
@@ -207,8 +207,7 @@ const UserProfileMobile = (props) => {
   };
 
   const handleTabChange = (e) => {
-    const newIndex = Number(e.target.value); // Ensure it's a number
-    setActiveIndex(newIndex);
+    onTabChange(Number(e.target.value));
   };
 
   const handleTabSwitch = (tab) => {
@@ -313,10 +312,10 @@ const UserProfileMobile = (props) => {
           mb="12%"
           fontSize="0.9rem"
           isManual
-          index={activeIndex}
+          index={activeTabIndex}
         >
           <Select
-            value={activeIndex}
+            value={activeTabIndex}
             onChange={handleTabChange}
             mb={4}
             bg="#F6FAFF"
@@ -327,10 +326,11 @@ const UserProfileMobile = (props) => {
             mx="auto"
             fontWeight="semibold"
           >
-            <option value={0}>Signup Links</option>
-            <option value={1}>Sermon Notes</option>
-            <option value={2}>Personal Profile</option>
-            <option value={3}>Church Profile</option>
+            {PROFILE_TABS.map((tab, index) => (
+              <option key={tab.slug} value={index}>
+                {tab.label}
+              </option>
+            ))}
           </Select>
           <TabPanels>
             <TabPanel width="full" margin="20px 0px" p="0">

--- a/ui/src/pages/userProfile/profileTabs.js
+++ b/ui/src/pages/userProfile/profileTabs.js
@@ -1,0 +1,16 @@
+// Single source of truth for the profile tabs. Desktop renders them as <Tab>
+// children and mobile as <option> values, so both orderings come from this array.
+export const PROFILE_TABS = [
+  { slug: 'signup-links', label: 'Signup Links' },
+  { slug: 'sermon-notes', label: 'Sermon Notes' },
+  { slug: 'personal-profile', label: 'Personal Profile' },
+  { slug: 'church-profile', label: 'Church Profile' },
+];
+
+export const DEFAULT_PROFILE_TAB = PROFILE_TABS[0].slug;
+
+export const getProfileTabIndex = (slug) =>
+  PROFILE_TABS.findIndex((tab) => tab.slug === slug);
+
+export const getProfileTabSlug = (index) =>
+  PROFILE_TABS[index]?.slug ?? DEFAULT_PROFILE_TAB;


### PR DESCRIPTION
Each of the four profile tabs is now addressable at `/profile/<slug>` (`signup-links`, `sermon-notes`, `personal-profile`, `church-profile`), with bare `/profile` and unrecognised slugs redirecting to the first tab. `PrivateRoute`'s profile-completion gate matched `/profile` by exact string, so it now matches the sub-paths too. Not yet exercised in a browser — needs a click-through of the four tabs and the back button.

Closes #1431