### PR TITLE
GH-1436: fill live sermon passage from published sermon notes

### DIFF
--- a/server/api/controllers/sermonNotesParent/get-sermon-notes-parent.js
+++ b/server/api/controllers/sermonNotesParent/get-sermon-notes-parent.js
@@ -8,6 +8,15 @@ module.exports = {
       required: false,
       type: 'string',
     },
+    date: {
+      required: false,
+      type: 'string',
+      description: 'Service date in yyyy-MM-dd format',
+    },
+    isPublished: {
+      required: false,
+      type: 'boolean',
+    },
     includeDeleted: {
       required: false,
       type: 'boolean',
@@ -27,7 +36,7 @@ module.exports = {
     },
   },
 
-  fn: async function ({ sermonId, includeDeleted }, exits) {
+  fn: async function ({ sermonId, date, isPublished, includeDeleted }, exits) {
     try {
       let query = {};
       if (!includeDeleted) {
@@ -36,6 +45,14 @@ module.exports = {
 
       if (sermonId) {
         query.sermonId = sermonId;
+      }
+
+      if (date) {
+        query.date = date;
+      }
+
+      if (isPublished !== undefined) {
+        query.isPublished = isPublished;
       }
 
       const data = await SermonNotesParent.find(query);

--- a/ui/src/pages/admin/liveSermon/AdminLiveSermonContainer.js
+++ b/ui/src/pages/admin/liveSermon/AdminLiveSermonContainer.js
@@ -39,6 +39,7 @@ export default function AdminLiveSermonContainer(props) {
   const [streamStartTime, setStreamStartTime] = useState('');
   const [streamEndTime, setStreamEndTime] = useState('');
   const [streamPeriodInvalid, setStreamPeriodInvalid] = useState(false);
+  const [isLoadingPassage, setIsLoadingPassage] = useState(false);
 
   const initLiveSermonValues = (data) => {
     setId(data.id);
@@ -208,6 +209,40 @@ export default function AdminLiveSermonContainer(props) {
     getData();
   }, [getData]);
 
+  // The bible passage mirrors the sermon notes published for the same service
+  // date. Several notes can exist for one date; the extras are test records, so
+  // only published ones count and the newest sermonId wins.
+  const getPassageFromSermonNotes = useCallback(async (dateTime) => {
+    const serviceDate = DateTime.fromISO(dateTime);
+    if (!serviceDate.isValid) return;
+
+    setIsLoadingPassage(true);
+    try {
+      const { data } = await axios.get('/api/sermon-notes-parent/get', {
+        params: {
+          date: serviceDate.toFormat('yyyy-MM-dd'),
+          isPublished: true,
+        },
+      });
+      const [latest] = [...data].sort((a, b) =>
+        (b.sermonId ?? '').localeCompare(a.sermonId ?? '')
+      );
+      if (latest && latest.passage) {
+        setSermonPassage(latest.passage);
+      }
+    } catch (err) {
+      console.log(err);
+    } finally {
+      setIsLoadingPassage(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (sermonDateTime) {
+      getPassageFromSermonNotes(sermonDateTime);
+    }
+  }, [sermonDateTime, getPassageFromSermonNotes]);
+
   useEffect(() => {
     if (streamStartTime && streamEndTime) {
       const startTime = DateTime.fromISO(streamStartTime);
@@ -302,8 +337,13 @@ export default function AdminLiveSermonContainer(props) {
                   <Input
                     type="text"
                     value={sermonPassage}
+                    isDisabled={isLoadingPassage}
                     onChange={(e) => setSermonPassage(e.target.value)}
                   />
+                  <FormHelperText>
+                    Filled in from the published sermon notes for the selected
+                    date. Edit it here to override.
+                  </FormHelperText>
                 </FormControl>
                 <FormControl isRequired isInvalid={sermonDateTime === ''}>
                   <FormLabel>Date &#38; Time</FormLabel>


### PR DESCRIPTION
Closes #1436

The Sermon Passage field in the Live Sermon Manager is now filled in from the sermon notes matching the selected service date, taking the published record with the newest `sermonId` when several exist for that date, and staying editable as an override.